### PR TITLE
Added function: "saveWallpaper", and option "set image as Lockscreen wallpaper"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,7 @@
 ---
 Title: Set Wallpaper
-Description: Set an image within the application cordova as wallpaper.
+Description: Set an image from a Cordova Android app as Homescreen or Lockscreen wallpaper.
 ---
-
-[![npm version][version-img]][version-url]
-
-[![Code Climate][cc-img]][cc-url]
-[![Issue Count][cc-issues-img]][cc-issues-url]
-
-|Android|
-|:-:|
-|[![Build Status][android-img]][android-url]|
 
 # cordova-plugin-wallpaper
 

--- a/README.md
+++ b/README.md
@@ -23,57 +23,82 @@ This simple plugin gives you the ability of setting the systems wallpaper, eithe
 4. [Supported Platforms](#supported-platforms)
 
 ## Installation
-stable npm package:
 ```
-cordova plugin add cordova-plugin-wallpaper
-```
-
-maybe unstable GitHub-repository:
-```
-cordova plugin add https://github.com/fbsanches/cordova-plugin-wallpaper.git
+cordova plugin add https://github.com/ragcsalo/cordova-plugin-wallpaper.git
 ```
 
 ## Usage
 ### Function(s)
-#### setImage
-Sets image under given path as systems background image:
+
+#### saveWallpaper
+Saves the current Homescreen wallpaper as a Base64 string to Shared Preferences:
 ```javascript
-window.plugins.wallpaper.setImage(string /* image path */);
+window.plugins.wallpaper.saveWallpaper();
+```
+
+##### Notes
+ - Homescreen wallpaper is stored as a Base64 string
+ - saved to Shared Preferences named "WallpaperPref", in a String named "original_wallpaper"
+ - if you want to restore the saved wallpaper, you can use the SharedPreferences plugin to retrieve it:
+ 
+```
+cordova plugin add https://github.com/ragcsalo/SharedPreferences.git
+```
+
+##### Example: retrieve and restore the saved wallpaper
+```javascript
+sharedpreferences.getSharedPreferences("WallpaperPref", "MODE_PRIVATE", function() {
+  sharedpreferences.getString("original_wallpaper", function(wp64){
+    window.plugins.wallpaper.setImageBase64(wp64);
+  }, function(err) {console.log('ERROR: '+err);});
+}, function(err) {console.log('ERROR: '+err);});
+```
+
+---
+
+#### setImage
+Sets image under given path as Homescreen or Lockscreen background image:
+```javascript
+window.plugins.wallpaper.setImage(string [image path], string [type]);
 ```
 
 ##### Notes
  - path must not start with bar
  - path has not to start with backslash
+ - add second parameter 'lock' if you want to set the Lockscreen wallpaper
 
 ##### Example
 ```javascript
-window.plugins.wallpaper.setImage('img/mybackground.jpg');
+window.plugins.wallpaper.setImage('img/mybackground.jpg'); // set Homescreen wallpaper
+window.plugins.wallpaper.setImage('img/mybackground.jpg','lock'); // set Lockscreen wallpaper
 ```
 
 ---
 
 #### setImageHttp
-Sets image from url as background image:
+Sets image from URL as background image:
 ```javascript
-window.plugins.wallpaper.setImageHttp(string /* url */);
+window.plugins.wallpaper.setImageHttp(string [image URL], string [type]);
 ```
 
 ##### Example
 ```javascript
-window.plugins.wallpaper.setImageHttp('https://example.com/image.jpg');
+window.plugins.wallpaper.setImageHttp('https://example.com/image.jpg'); // set Homescreen wallpaper
+window.plugins.wallpaper.setImageHttp('https://example.com/image.jpg','lock'); // set Lockscreen wallpaper
 ```
 
 ---
 
 #### setImageBase64
-Sets image contained in Base64 string as systems background image:
+Sets image contained in Base64 string as background image:
 ```javascript
-window.plugins.wallpaper.setImageBase64(string /* Base64 string */);
+window.plugins.wallpaper.setImageBase64(string [Base64 string], string [type]);
 ```
 
 ##### Example
 ```javascript
-window.plugins.wallpaper.setImageBase64(base64);
+window.plugins.wallpaper.setImageBase64(base64); // set Homescreen wallpaper
+window.plugins.wallpaper.setImageBase64(base64,'lock'); // set Lockscreen wallpaper
 ```
 
 ### Callbacks

--- a/src/android/wallpaper.java
+++ b/src/android/wallpaper.java
@@ -1,16 +1,24 @@
 package fc.fcstudio;
 
-import org.apache.cordova.CordovaPlugin;
-import org.apache.cordova.CallbackContext;
-import org.json.JSONArray;
-import org.json.JSONException;
 import android.app.WallpaperManager;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.util.Base64;
+import android.util.Log;
+
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -18,6 +26,7 @@ public class wallpaper extends CordovaPlugin
 {
 	public Context context = null;
 	private static final boolean IS_AT_LEAST_LOLLIPOP = Build.VERSION.SDK_INT >= 21;
+	public static SharedPreferences saved_settings;
 	
 	@Override
 	public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException
@@ -25,12 +34,44 @@ public class wallpaper extends CordovaPlugin
 		context = IS_AT_LEAST_LOLLIPOP ? cordova.getActivity().getWindow().getContext() : cordova.getActivity().getApplicationContext();
 		String imgSrc = "";
 		Boolean base64 = false;
-		
+
 		if (action.equals("start"))
 		{
 			imgSrc = args.getString(0);
 			base64 = args.getBoolean(1);
 			this.echo(imgSrc, base64, context);
+			PluginResult pr = new PluginResult(PluginResult.Status.OK);
+			pr.setKeepCallback(true);
+			callbackContext.sendPluginResult(pr);
+			return true;
+		}
+		else if (action.equals("lockscreen"))
+		{
+			imgSrc = args.getString(0);
+			base64 = args.getBoolean(1);
+			this.setlockwp(imgSrc, base64, context);
+			PluginResult pr = new PluginResult(PluginResult.Status.OK);
+			pr.setKeepCallback(true);
+			callbackContext.sendPluginResult(pr);
+			return true;
+		}
+		else if (action.equals("save_homescreen_wp"))
+		{
+			final WallpaperManager wallpaperManager = WallpaperManager.getInstance(context);
+			Drawable wallpaper_profile = wallpaperManager.getDrawable();
+			Bitmap bitmap_profile = ((BitmapDrawable) wallpaper_profile).getBitmap();
+
+			ByteArrayOutputStream baos_profile = new ByteArrayOutputStream();
+			bitmap_profile.compress(Bitmap.CompressFormat.JPEG, 100, baos_profile);
+			final byte[][] b_profile = {baos_profile.toByteArray()};
+			String encodedImage_profile = Base64.encodeToString(b_profile[0], Base64.DEFAULT);
+
+			saved_settings = context.getSharedPreferences("WallpaperPref", Context.MODE_PRIVATE);
+			SharedPreferences.Editor edit = saved_settings.edit();
+			edit.putString("original_wallpaper", encodedImage_profile);
+			edit.commit();
+			Log.d("console", "homescreen_wallpaper saved: "+encodedImage_profile);
+
 			PluginResult pr = new PluginResult(PluginResult.Status.OK);
 			pr.setKeepCallback(true);
 			callbackContext.sendPluginResult(pr);
@@ -58,6 +99,36 @@ public class wallpaper extends CordovaPlugin
 			}
 			WallpaperManager myWallpaperManager = WallpaperManager.getInstance(context);
 			myWallpaperManager.setBitmap(bitmap);
+			Log.d("console", "homescreen wallpaper set");
+		}
+		catch (IOException e)
+		{
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+	public void setlockwp(String image, Boolean base64, Context context)
+	{
+		try
+		{
+			AssetManager assetManager = context.getAssets();
+			Bitmap bitmap;
+			if(base64) //Base64 encoded
+			{
+				byte[] decoded = android.util.Base64.decode(image, android.util.Base64.DEFAULT);
+				bitmap = BitmapFactory.decodeByteArray(decoded, 0, decoded.length);
+			}
+			else //normal path
+			{
+				InputStream instr = assetManager.open("www/" + image);
+				bitmap = BitmapFactory.decodeStream(instr);
+			}
+			if (android.os.Build.VERSION.SDK_INT>=24) {
+				WallpaperManager ujWallpaperManager = WallpaperManager.getInstance(context);
+				ujWallpaperManager.setBitmap(bitmap, null, true, WallpaperManager.FLAG_LOCK);
+				Log.d("console", "lockscreen wallpaper set");
+			}
 		}
 		catch (IOException e)
 		{

--- a/www/wallpaper.js
+++ b/www/wallpaper.js
@@ -1,6 +1,7 @@
+cordova.define("cordova-plugin-wallpaper.wallpaper", function(require, exports, module) {
 function wallpaper() {}
 
-wallpaper.prototype.setImage = function(image, callback) {
+wallpaper.prototype.setImage = function(image, type, callback) {
     var services = "wallpaper";
     var dependentProperties = [];
     dependentProperties.push(image, false);
@@ -15,12 +16,32 @@ wallpaper.prototype.setImage = function(image, callback) {
     };
 
     var action = "start"; //future actions new entries. Fixed.
+    if (type=="lock") {
+      action="lockscreen";
+    }
     if (image) {
         cordova.exec(successCallback, errorCallback, services, action, dependentProperties);
     }
 };
 
-function setBase64(base64, callback) {
+wallpaper.prototype.saveWallpaper = function(callback) {
+    var services = "wallpaper";
+    var dependentProperties = [];
+
+    var successCallback = function() {
+      typeof callback === 'function' && callback();
+    };
+
+    var errorCallback = function(error) {
+      var errorBack = error || 'unknown cordova error when setting wallpaper';
+      typeof callback === 'function' && callback(errorBack);
+    };
+
+    var action = "save_homescreen_wp";
+    cordova.exec(successCallback, errorCallback, services, action, dependentProperties);
+};
+
+function setBase64(base64, type, callback) {
     var services = "wallpaper";
     var dependentProperties = [];
     dependentProperties.push(base64, true);
@@ -35,6 +56,9 @@ function setBase64(base64, callback) {
     };
 
     var action = "start"; //future actions new entries. Fixed.
+    if (type=="lock") {
+      action="lockscreen";
+    }
     if(base64) {
         cordova.exec(successCallback, errorCallback, services, action, dependentProperties);
     }
@@ -44,7 +68,7 @@ wallpaper.prototype.setImageBase64 = function(base64, callback) {
     setBase64(base64, callback);
 };
 
-wallpaper.prototype.setImageHttp = function(url, callback) {
+wallpaper.prototype.setImageHttp = function(url, type, callback) {
     var request = null;
     if(window.XMLHttpRequest) {
         request = new XMLHttpRequest();
@@ -70,7 +94,7 @@ wallpaper.prototype.setImageHttp = function(url, callback) {
                 raw += String.fromCharCode.apply(null, subArray);
             }
             var base64 = btoa(raw);
-            setBase64(base64, callback);
+            setBase64(base64, type, callback);
         }
         function XHRerror(error) {
             typeof callback === 'function' && callback(error);
@@ -97,3 +121,5 @@ wallpaper.install = function() {
 };
 
 cordova.addConstructor(wallpaper.install);
+
+});


### PR DESCRIPTION
**New function: saveWallpaper**
Description: Saves the current Homescreen wallpaper as a Base64 string to Shared Preferences named "WallpaperPref", in a String named "original_wallpaper". Use the SharedPreferences plugin to retrieve it.

**New option: set image as Lockscreen wallpaper**
Description: add second parameter with value 'lock' to set the Lockscreen wallpaper instead of the Homescreen wallpaper. This second parameter works with "setImage", "setImageHttp" and "setImageBase64".